### PR TITLE
Complete Home Assistant integration with cumulative water tracking

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,9 +10,26 @@
     "mqtt": {
         "broker": "192.168.1.100",
         "port": 1883,
-        "topic": "irrigation/water_meter",
         "client_id": "pico_water_meter",
         "user": "your_mqtt_username",
         "password": "your_mqtt_password"
+    },
+    "homeassistant": {
+        "discovery_topic": "homeassistant/sensor/water_meter/config",
+        "state_topic": "homeassistant/sensor/water_meter/state",
+        "command_topic": "homeassistant/sensor/water_meter/set",
+        "availability_topic": "homeassistant/sensor/water_meter/availability",
+        "device": {
+            "unique_id": "water_meter_001",
+            "name": "Water Usage",
+            "device_class": "water",
+            "unit_of_measurement": "L",
+            "device_info": {
+                "identifiers": ["water_meter_001"],
+                "name": "Water Meter",
+                "model": "Generic Water Counter",
+                "manufacturer": "DIY"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
• Full Home Assistant MQTT integration with automatic device discovery
• Cumulative water usage tracking with persistent storage
• Remote command support for setting cumulative values
• Enhanced availability tracking with last will and birth messages

## Changes
• **MQTT Discovery**: Automatic device registration in Home Assistant without manual configuration
• **Cumulative Tracking**: Persistent water usage counter stored in `water_usage.txt` file
• **Remote Commands**: Listen to MQTT command topic to remotely set cumulative values
• **Availability Status**: Last will message ("offline") and birth message ("online") for connection status
• **Enhanced Topics**: Dedicated topics for discovery, state, commands, and availability
• **Real-time Updates**: MQTT message callback handling for immediate command processing

## Features
- Device automatically appears in Home Assistant after first connection
- Water usage persists through device resets and power cycles
- Remote reset/adjustment of cumulative values via Home Assistant
- Online/offline status tracking in Home Assistant
- Cumulative liter reporting instead of individual rotation events

## Test plan
- [ ] Verify device discovery message creates sensor in Home Assistant
- [ ] Confirm cumulative usage increments and persists across restarts
- [ ] Test remote cumulative value setting via MQTT command topic
- [ ] Validate availability status shows online/offline correctly
- [ ] Check water usage display updates in real-time in Home Assistant

🤖 Generated with [Claude Code](https://claude.ai/code)