### PR TITLE
Fix Home Assistant sensor state class configuration

### DIFF
--- a/config.json
+++ b/config.json
@@ -24,6 +24,7 @@
             "name": "Water Usage",
             "device_class": "water",
             "unit_of_measurement": "L",
+            "state_class": "total",
             "device_info": {
                 "identifiers": ["water_meter_001"],
                 "name": "Water Meter",

--- a/main.py
+++ b/main.py
@@ -95,7 +95,8 @@ class WaterMeterDetector:
                     "device_class": ha_config["device"]["device_class"],
                     "state_topic": ha_config["state_topic"],
                     "command_topic": ha_config["command_topic"],
-                    "unit_of_measurement": ha_config["device"]["unit_of_measurement"],                    
+                    "unit_of_measurement": ha_config["device"]["unit_of_measurement"],
+                    "state_class": ha_config["device"]["state_class"],
                     "unique_id": ha_config["device"]["unique_id"],
                     "availability_topic": ha_config["availability_topic"],
                     "device": ha_config["device"]["device_info"]


### PR DESCRIPTION
## Summary
- Add missing `state_class` property to Home Assistant sensor configuration
- Set state class to `"total"` to properly support cumulative water usage tracking with correction capabilities
- Update discovery message to include the state class from configuration

## Test plan
- [ ] Verify JSON configuration loads without errors
- [ ] Test Home Assistant discovery message includes state_class
- [ ] Confirm sensor appears correctly in Home Assistant with proper statistics support
- [ ] Validate existing MQTT correction functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)