### PR TITLE
Improve MQTT reliability with configurable keep-alive and retain flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ See [WIRING.md](WIRING.md) for complete hardware wiring instructions.
         "port": 1883,
         "client_id": "pico_water_meter",
         "user": "your_mqtt_username",
-        "password": "your_mqtt_password"
+        "password": "your_mqtt_password",
+        "keep_alive_seconds": 30
     },
     "homeassistant": {
         "discovery_topic": "homeassistant/sensor/water_meter/config",

--- a/config.json
+++ b/config.json
@@ -8,7 +8,8 @@
         "port": 1883,
         "client_id": "pico_water_meter",
         "user": "your_mqtt_username",
-        "password": "your_mqtt_password"
+        "password": "your_mqtt_password",
+        "keep_alive_seconds": 30
     },
     "sensor": {
         "pin": 3,

--- a/main.py
+++ b/main.py
@@ -84,7 +84,8 @@ class WaterMeterDetector:
                 self.config["mqtt"]["broker"],
                 port=self.config["mqtt"]["port"],
                 user=self.config["mqtt"]["user"],
-                password=self.config["mqtt"]["password"]
+                password=self.config["mqtt"]["password"],
+                keepalive=self.config["mqtt"].get("keep_alive_seconds", 60)
             )
             
             # Set last will message before connecting
@@ -121,7 +122,7 @@ class WaterMeterDetector:
         if self.mqtt_client:
             try:
                 availability_topic = self.config["homeassistant"]["availability_topic"]
-                self.mqtt_client.publish(availability_topic, "online")
+                self.mqtt_client.publish(availability_topic, "online", retain=True)
                 self.logger.info("Birth message sent")
             except Exception as e:
                 self.logger.error(f"Birth message failed: {e}")
@@ -196,8 +197,8 @@ class WaterMeterDetector:
                 state_topic = self.config["homeassistant"]["state_topic"]
                 json_attributes_topic = self.config["homeassistant"]["json_attributes_topic"]
                 
-                # Send state value
-                self.mqtt_client.publish(state_topic, str(self.cumulative_usage))
+                # Send state value with retain flag
+                self.mqtt_client.publish(state_topic, str(self.cumulative_usage), retain=True)
                 
                 # Gather diagnostic data for attributes
                 wifi_rssi = self._get_wifi_signal_strength()
@@ -221,8 +222,8 @@ class WaterMeterDetector:
                     "sensor_debounce_ms": self.config["sensor"]["debounce_ms"]
                 }
                 
-                # Send attributes
-                self.mqtt_client.publish(json_attributes_topic, json.dumps(attributes_data))
+                # Send attributes with retain flag
+                self.mqtt_client.publish(json_attributes_topic, json.dumps(attributes_data), retain=True)
                 
                 self.logger.debug(f"Water usage and attributes sent: {self.cumulative_usage}L")
                 self.mqtt_reconnect_attempts = 0  # Reset on successful publish


### PR DESCRIPTION
## Summary
- Add configurable MQTT keep-alive interval for faster offline detection
- Implement retain flags for critical MQTT topics to ensure data persistence
- Improve system reliability during network interruptions and broker restarts

## Changes Made
- **Configurable Keep-Alive**: Added `keep_alive_seconds` to MQTT config (default 30s vs 60s+ default)
- **State Retention**: Water meter values now persist with `retain=True` on state topic
- **Availability Retention**: Online/offline status retained for consistent availability state
- **Attributes Retention**: Diagnostic data persists across broker restarts
- **Documentation**: Updated README.md with new configuration option

## Benefits
- **Faster Offline Detection**: 30-second keep-alive reduces time to detect power loss
- **Data Persistence**: Critical values survive MQTT broker restarts
- **Improved Reliability**: Home Assistant shows correct state immediately upon reconnection
- **Better Monitoring**: Diagnostic attributes remain available during brief disconnections

## Test Plan
- [ ] Verify keep-alive interval is configurable and defaults work correctly
- [ ] Test that water meter values persist after MQTT broker restart
- [ ] Confirm availability status is retained properly
- [ ] Validate diagnostic attributes persist across disconnections
- [ ] Test offline detection timing with new keep-alive setting

🤖 Generated with [Claude Code](https://claude.ai/code)